### PR TITLE
feat: Add Docker support with smart dependency caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+ENV/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# ChromaDB (will be created in volume)
+chroma_data/
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+*.md
+!README.md
+
+# Logs
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Backend Dockerfile for FastAPI
+FROM python:3.11-slim
+
+# Build argument to control dependency caching
+# Set to "false" for local dev (uses cache), "true" for VPS (rebuilds)
+ARG REBUILD_DEPS=false
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    default-libmysqlclient-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies with conditional caching
+# When REBUILD_DEPS=true, --no-cache-dir forces fresh install
+# When REBUILD_DEPS=false, uses Docker layer cache
+RUN if [ "$REBUILD_DEPS" = "true" ]; then \
+        pip install --no-cache-dir --force-reinstall -r requirements.txt; \
+    else \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
+
+# Copy application code
+COPY . .
+
+# Create directory for ChromaDB data
+RUN mkdir -p /app/chroma_data
+
+# Expose port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD python -c "import requests; requests.get('http://localhost:8000/health')" || exit 1
+
+# Run migrations and start server
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,36 @@
+# Development Dockerfile with hot-reload
+FROM python:3.11-slim
+
+# Build argument to control dependency caching
+ARG REBUILD_DEPS=false
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    default-libmysqlclient-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements
+COPY requirements.txt .
+
+# Install Python dependencies with conditional caching
+RUN if [ "$REBUILD_DEPS" = "true" ]; then \
+        pip install --no-cache-dir --force-reinstall -r requirements.txt; \
+    else \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
+
+# Copy application code
+COPY . .
+
+# Create ChromaDB directory
+RUN mkdir -p /app/chroma_data
+
+EXPOSE 8000
+
+# Development server with auto-reload
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]

--- a/app/main.py
+++ b/app/main.py
@@ -106,3 +106,9 @@ app.include_router(memory.router)
 @app.get("/")
 def root():
     return {"status": "alive", "version": __version__}
+
+
+@app.get("/health")
+def health_check():
+    """Health check endpoint for Docker and monitoring"""
+    return {"status": "healthy", "version": __version__}


### PR DESCRIPTION
- Add Dockerfile with REBUILD_DEPS build argument for optimized builds
- Add Dockerfile.dev for development with hot-reload
- Add .dockerignore to exclude unnecessary files
- Add /health endpoint for Docker health checks and monitoring
- Configure build caching: local dev uses cache, VPS rebuilds fresh

This enables efficient Docker deployments with bandwidth optimization for slow connections while ensuring clean production builds.